### PR TITLE
Genet project dead/vanished

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,7 +589,6 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 
 *Troubleshooting Tools.*
 
-* [genet](https://github.com/genet-app/genet) - Caffeinated Packet Analyzer.
 * [grml](https://grml.org) – bootable Debian Live CD with powerful CLI tools.
 * [mitmproxy](http://mitmproxy.org/) - A Python tool used for intercepting, viewing and modifying network traffic. Invaluable in troubleshooting certain problems.
 * [mtr](https://www.bitwizard.nl/mtr/) - Network utility that combines traceroute and ping.


### PR DESCRIPTION
### Application name / category
genet / Troubleshooting

Both the github repo and user no longer exist on github and I did not find any website for the app.

The only page I could find is the [AppImage on Github](https://appimage.github.io/genet/), but it does not have any information about the app and only dead links.