### PR TITLE
Add outline vpn

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 * [tinc](http://www.tinc-vpn.org/) - Distributed p2p VPN.
 * [WireGuard](https://www.wireguard.com/) - Very fast VPN based on elliptic curve and public key crypto.
 * [Nebula](https://github.com/slackhq/nebula) - A scalable p2p VPN with a focus on performance, simplicity and security.
+* [Outline](https://github.com/Jigsaw-Code/outline-server) - Outline Manager application creates and manages Outline servers, powered by Shadowsocks, for all major platforms.
 
 ## Web
 


### PR DESCRIPTION
Adding outline VPN service

### Application name / category
[outline](https://getoutline.org/) / VPN

### Source URL
https://github.com/Jigsaw-Code/outline-server
### why it is awesome
This tool is so awesome because it allows everyone to deploy a VPN service with one click and trivial management. It is available for major platforms. 
