### PR TITLE
add adguard home to control panels dns

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@
   * [VestaCP](http://vestacp.com/) - Hosting panel for Linux but with Nginx.
   * [Virtualmin](http://www.virtualmin.com/) - Hosting panel for Linux based on webmin.
 * DNS
+  * [Adguard Home](https://github.com/AdguardTeam/AdGuardHome) - Network-wide ads & trackers blocking DNS server
   * [Atomia DNS](http://atomiadns.com/) - DNS management system.
   * [nsedit](https://github.com/tuxis-ie/nsedit) - nsedit is a DNS editor for PowerDNS, working with PowerDNS's new API.
   * [PDNS Gui](https://github.com/odoucet/pdns-gui) - WebGUI which aids in administering domains and records for PowerDNS with MySQL.


### PR DESCRIPTION
### Application name / category
[Adguard Home](https://github.com/AdguardTeam/AdGuardHome) / Control Panels

### Source URL
https://github.com/AdguardTeam/AdGuardHome

### why it is awesome
This tool is so awesome because it allows Network-wide ads & trackers blocking DNS server
