### PR TITLE
Change statping for statping-ng (active fork)

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@
 * [System Status Dashboard (SSD)](http://www.system-status-dashboard.com/) - Overview about an organization's infrastructure health status.
 * [Staytus](http://staytus.co/) - Staytus is a complete solution for publishing the latest information about any issues with your web applications, networks or services.
 * [vigil](https://github.com/valeriansaliou/vigil) -  Microservices Status Page. Monitors a distributed infrastructure and sends alerts to Slack. Written in Rust.
-* [Statping](https://github.com/hunterlong/statping) - Status page system written in Go.
+* [Statping-ng](https://github.com/statping-ng/statping-ng) - Status page system written in Go (Active fork of statping).
 * [Uptime Kuma](https://github.com/louislam/uptime-kuma) - Self-hosted status page similar to "Uptime Robot".
 * [netcheck](https://demo.ncheck.eu/#/info) – Simple ping status system written in Java, similar to Pingdom and StatusCake.
 


### PR DESCRIPTION
### Application name / category
[statping-ng](https://github.com/statping-ng/statping-ng) / Devops

### Source URL
https://github.com/statping-ng/statping-ng

### why it is awesome
statping was abandonned and statping-ng was the new active fork
