### PR TITLE
Updated Duplicity Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@
 * [BorgBackup](https://github.com/borgbackup/borg) - A fork of [Attic](https://attic-backup.org) deduplicating backup program written in Python.
 * [Burp](http://burp.grke.org/) - Network backup and restore program.
 * [Duplicati](http://www.duplicati.com) - Multiple backends, encryption, web-ui and multi-OS backup tool.
-* [Duplicity](http://duplicity.nongnu.org/) - Encrypted bandwidth-efficient backup using the rsync algorithm.
+* [Duplicity](https://duplicity.gitlab.io/) - Encrypted bandwidth-efficient backup using the rsync algorithm.
 * [Elkarbackup](https://github.com/elkarbackup/elkarbackup) - Backup solution based on RSnapshot with a simple web interface
 * [rclone](https://rclone.org/) - a command line program to sync files and directories to and from several cloud storage systems/providers.
 * [Rdiff-backup](http://www.nongnu.org/rdiff-backup/) - An easy A remote incremental backup of all your files.


### PR DESCRIPTION
Duplicity moved to GitLab and therefore the link needed updated
Didnt fill below due to link change and not adding

---------------------------
### Application name / category
[awesometool](https://example.com) / Devops

### Source URL
https://github.example.com/repo

### why it is awesome
This tool is so awesome because it allows me to do awesome things in my
awesome corp, especially when I use it to manage awesome othersoftware.
