### PR TITLE
Added Headscale VPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 
 *VPN software.*
 
+* [Headscale](https://github.com/juanfont/headscale) - Self-hostable fork of [Tailscale](https://tailscale.com), cross-platform clients, simple to use, built-in (currently experimental) monitoring tools. 
 * [ocserv](http://www.infradead.org/ocserv/) - Cisco AnyConnect-compatible VPN server
 * [OpenVPN](https://community.openvpn.net) - Uses a custom security protocol that utilizes SSL/TLS for key exchange.
 * [Pritunl](http://pritunl.com/) - OpenVPN based solution. Easy to set up.


### PR DESCRIPTION
Headscale is a community maintained fork of Tailscale VPN, which provides docker image and documentation for self hosting.

### Application name / category
[Headscale](https://github.com/juanfont/headscale) / VPN

### Source URL
https://github.com/juanfont/headscale

### why it is awesome
Headscale is a self hosted version of Tailscale VPN which is simple to use and has ready-to-go OOBE.
It supports SSO, multiple users in a team, monitoring services, etc.