### PR TITLE
Add Dockovpn to VPN list

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 
 *VPN software.*
 
-* [Dockovpn](https://dockovpn.io) - Out of the box stateless dockerized openvpn compartible server which starts in less than 2 seconds.
+* [Dockovpn](https://dockovpn.io) - Out-of-the-box stateless dockerized OpenVPN-compartible server which starts in less than 2 seconds.
 * [Firezone](https://www.firez.one/) - WireGuard based VPN Server and Firewall. 
 * [Headscale](https://github.com/juanfont/headscale) - Self-hostable fork of [Tailscale](https://tailscale.com), cross-platform clients, simple to use, built-in (currently experimental) monitoring tools. 
 * [ocserv](http://www.infradead.org/ocserv/) - Cisco AnyConnect-compatible VPN server

--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ _See also: [IT Asset Management]([Ralph](#it-asset-management))_
 
 *VPN software.*
 
-- [Dockovpn](https://dockovpn.io) - Out-of-the-box stateless dockerized OpenVPN-compatible server which starts in less than 2 seconds.
+- [Dockovpn](https://dockovpn.io) - Out-of-the-box stateless dockerized OpenVPN server which starts in less than 2 seconds.
 - [Firezone](https://www.firez.one/) - WireGuard based VPN Server and Firewall. 
 - [Headscale](https://github.com/juanfont/headscale) - Self-hostable fork of [Tailscale](https://tailscale.com), cross-platform clients, simple to use, built-in (currently experimental) monitoring tools. 
 - [Nebula](https://github.com/slackhq/nebula) - A scalable p2p VPN with a focus on performance, simplicity and security.

--- a/README.md
+++ b/README.md
@@ -642,6 +642,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 
 *VPN software.*
 
+* [Dockovpn](https://dockovpn.io) - Out of the box stateless dockerized openvpn compartible server which starts in less than 2 seconds.
 * [Firezone](https://www.firez.one/) - WireGuard based VPN Server and Firewall. 
 * [Headscale](https://github.com/juanfont/headscale) - Self-hostable fork of [Tailscale](https://tailscale.com), cross-platform clients, simple to use, built-in (currently experimental) monitoring tools. 
 * [ocserv](http://www.infradead.org/ocserv/) - Cisco AnyConnect-compatible VPN server

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 
 *VPN software.*
 
-* [Dockovpn](https://dockovpn.io) - Out-of-the-box stateless dockerized OpenVPN-compartible server which starts in less than 2 seconds.
+* [Dockovpn](https://dockovpn.io) - Out-of-the-box stateless dockerized OpenVPN-compatible server which starts in less than 2 seconds.
 * [Firezone](https://www.firez.one/) - WireGuard based VPN Server and Firewall. 
 * [Headscale](https://github.com/juanfont/headscale) - Self-hostable fork of [Tailscale](https://tailscale.com), cross-platform clients, simple to use, built-in (currently experimental) monitoring tools. 
 * [ocserv](http://www.infradead.org/ocserv/) - Cisco AnyConnect-compatible VPN server


### PR DESCRIPTION
### Dockovpn / VPN
[Dockovpn](https://dockovpn.io) / Devops

### Source URL
https://github.com/dockovpn/dockovpn

### Why it is awesome
Dockovpn is an out of the box dockerized OpenVPN compatible server, which starts in just a few seconds and runs forever.

### Have you used it? For how long?
I've been sing it since 2019 and find it very helpful as do a lot of other Dockovpn users.

### Is this in a personal or professional setup?
I've ben using it for both: personal and professional setups. Personally, I use it every time I need to virtually place myself elswhere in the world using any virtual private server. For professional setup, we're curently building a cloud hosted solution, which it capable of managing thousands of simultaneous users.

### How many devices/users/services/... do you manage with it?
I was capable of running it in a setup with dozens of simultaneous users.

### Biggest pros/cons compared to other solutions?
#### Pros
- Extremely easy to use
- Starts up in a few seconds
- Can be used in a stateless mode
- Code gets reviewed from cybersecurity professionals from all over the world
#### Cons
- As of now lacks support for Wireguard and IKEv2