### PR TITLE
Add Nomad to Cloud Orchestration list

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@
 * [Juju](https://jujucharms.com/) - Cloud orchestration tool which manages services as charms, YAML configuration and deployment script bundles.
 * [Kubernetes](http://kubernetes.io/) - Orchestration system for Docker containers - ([Source Code](https://github.com/kubernetes/kubernetes), [Documentation](http://kubernetes.io/docs/)) `Apache` `Go`
 * [MCollective](https://puppet.com/mcollective) - Ruby framework to manage server orchestration, developed by Puppet labs.
+* [Nomad](https://www.nomadproject.io) - Simple and flexible orchestrator for Docker, Podman, executables, Java, and QEMU - ([Source Code](https://github.com/hashicorp/nomad), [Documentation](https://www.nomadproject.io/docs)) `MPL-2.0` `Go`
 * [Overcast](http://andrewchilds.github.io/overcast/) - Deploy VMs across different cloud providers, and run commands and scripts across any or all of them in parallel via SSH.
 * [Rundeck](http://rundeck.org/) - Simple orchestration tool.
 * [Salt](http://saltstack.com/) - Fast, scalable and flexible systems management software written in Python/ZeroMQ.


### PR DESCRIPTION
### Application name / category
[Nomad](https://www.nomadproject.io) / Cloud Orchestration

### Source URL
https://github.com/hashicorp/nomad

### why it is awesome
Nomad supports more workloads than Kubernetes, supporting non-containerized executables, Java files, and QEMU. It is lightweight, using only about 1% CPU and 6% RAM on my 1GB model Raspberry Pi 4. On top of that, it is very extensible, with plugins that allow it to do things like orchestrate based on availability of GPU resources.
