### PR TITLE
Update limetext link

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ _See also: [IT Asset Management]([Ralph](#it-asset-management))_
 * [jotgit](https://github.com/jdleesmiller/jotgit) - Git-backed real-time collaborative code editing.
 * [KDevelop](https://www.kdevelop.org/) - IDE by the people behind KDE.
 * [Light Table](http://lighttable.com/) - The next generation code editor.
-* [Lime](http://limetext.org/) - Aims to provide an open source solution to Sublime Text
+* [Lime](https://limetext.github.io/) - Aims to provide an open source solution to Sublime Text
 * [Micro](https://micro-editor.github.io/) - A modern and intuitive terminal-based text editor
 * [Notepad++](https://notepad-plus-plus.org/) - GPLv2 multi-language editor with syntax highlighting for Windows.
 * [TextMate](https://github.com/textmate/textmate/) - A graphical text editor for OS X.

--- a/README.md
+++ b/README.md
@@ -332,7 +332,6 @@ _See also: [IT Asset Management]([Ralph](#it-asset-management))_
 * [jotgit](https://github.com/jdleesmiller/jotgit) - Git-backed real-time collaborative code editing.
 * [KDevelop](https://www.kdevelop.org/) - IDE by the people behind KDE.
 * [Light Table](http://lighttable.com/) - The next generation code editor.
-* [Lime](https://limetext.github.io/) - Aims to provide an open source solution to Sublime Text
 * [Micro](https://micro-editor.github.io/) - A modern and intuitive terminal-based text editor
 * [Notepad++](https://notepad-plus-plus.org/) - GPLv2 multi-language editor with syntax highlighting for Windows.
 * [TextMate](https://github.com/textmate/textmate/) - A graphical text editor for OS X.


### PR DESCRIPTION
http://limetext.org/ goes to a spam site not related to the Lime editor

i updated it to https://limetext.github.io/ that actually goes to something related to the editor