### PR TITLE
remove Bolo (unmaintained, homepage down)

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,6 @@ _See also: [IT Asset Management]([Ralph](#it-asset-management))_
 * [Adagios](http://adagios.org/) - Web based Nagios interface for configuration and monitoring (replacement to the standard interface), and a REST interface, [SourceCode](https://github.com/opinkerfi/adagios), [Documentation](https://github.com/opinkerfi/adagios/wiki))
 * [Alerta](https://github.com/guardian/alerta) - Distributed, scaleable and flexible monitoring system.
 * [Bloonix](https://bloonix-monitoring.org/) - Bloonix is a monitoring solution that helps businesses to ensure high availability and performance. `GPL-3.0` `Perl`
-* [bolo](http://bolo.niftylogic.com/) - A Do-it-Yourself monitoring framework built to gather metrics, mine data and report on the systems in your network.
 * [Bosun](http://bosun.org/) - Monitoring and alerting system by Stack Exchange ([Source Code](https://github.com/bosun-monitor/bosun), [Documentation](http://bosun.org/quickstart.html)) `MIT` `Go`
 * [Cacti](http://www.cacti.net) - Web-based network monitoring and graphing tool.
 * [Cabot](http://cabotapp.com/) - Monitoring and alerts, similar to PagerDuty.


### PR DESCRIPTION
- ref. https://github.com/awesome-foss/awesome-sysadmin/issues/405
- Bolo's homepage is a default nginx page. I found https://github.com/huntprod/bolo which looks like the source code, but hasn't had a commit since 2018.

<!-- DO NOT DELETE THE TEXT BELOW. Please make sure relevant boxes are checked [x] -->

Thank you for taking the time to work on a PR for Awesome-Sysadmin!

To ensure your PR is dealt with swiftly please check the following:

- [x] Any software project you are adding to the list is actively maintained.
