### PR TITLE
replace travis CI with github actions (check syntax, check links)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: make import
+      - run: make awesome_lint
+      - run: make url_check

--- a/.hecat/awesome-lint.yml
+++ b/.hecat/awesome-lint.yml
@@ -1,0 +1,8 @@
+steps:
+  - name: check data against awesome-sysadmin guidelines
+    module: processors/awesome_lint
+    module_options:
+      source_directory: ./
+      licenses_files:
+        - licenses.yml
+        - licenses-nonfree.yml

--- a/.hecat/import.yml
+++ b/.hecat/import.yml
@@ -1,0 +1,6 @@
+steps:
+  - name: import awesome-sysadmin README.md to YAML
+    module: importers/markdown_awesome
+    module_options:
+      source_file: ./README.md
+      output_directory: ./

--- a/.hecat/url-check.yml
+++ b/.hecat/url-check.yml
@@ -1,0 +1,11 @@
+steps:
+  - name: check URLs
+    module: processors/url_check
+    module_options:
+      source_directories:
+        - software
+        - tags
+      source_files:
+        - licenses.yml
+      errors_are_fatal: True
+      exclude_regex: []

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-rvm:
-  - 2.2
-before_script:
-  - gem install awesome_bot
-script:
-  - awesome_bot README.md --allow-dupe --allow-redirect --white-list bestpractical.com/rt,mogilefs,harding,archipel,linuxcontainers,spiceworks

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+SHELL := /bin/bash
+
+.PHONY: install # install build tools in a virtualenv
+install:
+	python3 -m venv .venv
+	source .venv/bin/activate && \
+	pip3 install wheel && \
+	pip3 install --force git+https://github.com/nodiscc/hecat.git@master
+
+.PHONY: import # import data from original list at https://github.com/awesome-foss/awesome-sysadmin
+import: install
+	rm -rf tags/ software/ platforms/
+	mkdir -p tags/ software/ platforms/
+	source .venv/bin/activate && \
+	hecat --config .hecat/import.yml
+
+.PHONY: awesome_lint # check data against awesome-sysadmin guidelines
+awesome_lint: install
+	source .venv/bin/activate && \
+	hecat --config .hecat/awesome-lint.yml
+
+.PHONY: url_check # check URLs for dead links or other connection problems
+url_check: install
+	source .venv/bin/activate && \
+	hecat --config .hecat/url-check.yml
+
+.PHONY: help # generate list of targets with descriptions
+help:
+	@grep '^.PHONY: .* #' Makefile | sed 's/\.PHONY: \(.*\) # \(.*\)/\1	\2/' | expand -t20


### PR DESCRIPTION
- travis CI free plans were discontinued
- CI pipeline is similar to https://github.com/awesome-selfhosted/awesome-selfhosted-data and uses https://github.com/nodiscc/hecat
- the pipeline will not pass until https://github.com/awesome-foss/awesome-sysadmin/issues/416 has been fixed
- ref. https://github.com/awesome-foss/awesome-sysadmin/issues/405
