### PR TITLE
Remove Atomia DNS website

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ _See also: [awesome-selfhosted/DNS](https://github.com/awesome-selfhosted/awesom
 
 _Related: [DNS - Servers](#dns---servers)_
 
-- [Atomia DNS](https://atomiadns.com/) - DNS management system. ([Source Code](https://github.com/atomia/atomiadns/)) `ISC` `Perl`
+- [Atomia DNS](https://github.com/atomia/atomiadns/) - DNS management system. `ISC` `Perl`
 - [Designate](https://wiki.openstack.org/wiki/Designate) - DNSaaS services for OpenStack. ([Source Code](https://opendev.org/openstack/designate)) `Apache-2.0` `Python`
 - [DNSControl](https://stackexchange.github.io/dnscontrol/) - Synchronize your DNS to multiple providers from a simple DSL. ([Source Code](https://github.com/StackExchange/dnscontrol)) `MIT` `Go/Docker`
 - [DomainMOD](https://domainmod.org) - Manage your domains and other internet assets in a central location. ([Source Code](https://github.com/domainmod/domainmod)) `GPL-3.0` `PHP`


### PR DESCRIPTION
Removes website of Atomia DNS as it is still broken