### PR TITLE
Exclude openvpn from url check

### DIFF
--- a/.hecat/url-check.yml
+++ b/.hecat/url-check.yml
@@ -8,4 +8,5 @@ steps:
       source_files:
         - licenses.yml
       errors_are_fatal: True
-      exclude_regex: []
+      exclude_regex:
+        - '^https://community.openvpn.net/$' # DDoS protection page, always returns 403


### PR DESCRIPTION
The website `https://community.openvpn.net/` employs Cloudflare as a defense against DDoS attacks. As a consequence, attempting to access the URL consistently leads to a 403 error.