### PR TITLE
Remove leading slash from openvpn url check

### DIFF
--- a/.hecat/url-check.yml
+++ b/.hecat/url-check.yml
@@ -9,4 +9,4 @@ steps:
         - licenses.yml
       errors_are_fatal: True
       exclude_regex:
-        - '^https://community.openvpn.net/$' # DDoS protection page, always returns 403
+        - '^https://community.openvpn.net$' # DDoS protection page, always returns 403


### PR DESCRIPTION
Fixes url check not excluding `https://community.openvpn.net` due to a leading slash (hopefully)