### PR TITLE
Added cloudray-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ _Related: [Databases](#databases), [Monitoring](#monitoring)_
 - [Statsd](https://github.com/etsy/statsd/) - Daemon that listens for statistics like counters and timers, sent over UDP or TCP, and sends aggregates to one or more pluggable backend services. `MIT` `Nodejs`
 - [tcollector](http://opentsdb.net/docs/build/html/user_guide/utilities/tcollector.html) - Gathers data from local collectors and pushes the data to OpenTSDB. ([Source Code](https://github.com/OpenTSDB/tcollector/)) `LGPL-3.0/GPL-3.0` `Python`
 - [Telegraf](https://github.com/influxdata/telegraf) - Plugin-driven server agent for collecting, processing, aggregating, and writing metrics. `MIT` `Go`
+- [CloudRay Agent](https://github.com/cloudray-io/cloudray-agent) - Lightweight agent to monitor and automate your Linux and macOS machine enabling secure, Bash scriptable infrastructure management without requiring SSH. `MIT` `Rust`
 
 
 ### Miscellaneous


### PR DESCRIPTION
Added [cloudray-agent](https://github.com/cloudray-io/cloudray-agent), a lightweight agent to monitor and automate your Linux and macOS machine, enabling secure, Bash scriptable infrastructure management without requiring SSH. 